### PR TITLE
Enable changing virt_wifi lower link dynamically

### DIFF
--- a/include/uapi/linux/if_link.h
+++ b/include/uapi/linux/if_link.h
@@ -1248,4 +1248,13 @@ struct ifla_rmnet_flags {
 	__u32	mask;
 };
 
+/* virt_wifi section */
+enum {
+	IFLA_VIRTWIFI_UNSPEC,
+	IFLA_VIRTWIFI_LOWER,
+	__IFLA_VIRTWIFI_MAX,
+};
+
+#define IFLA_VIRTWIFI_MAX (__IFLA_VIRTWIFI_MAX - 1)
+
 #endif /* _LINUX_IF_LINK_H */

--- a/ip/Makefile
+++ b/ip/Makefile
@@ -11,7 +11,7 @@ IPOBJ=ip.o ipaddress.o ipaddrlabel.o iproute.o iprule.o ipnetns.o \
     iplink_bridge.o iplink_bridge_slave.o ipfou.o iplink_ipvlan.o \
     iplink_geneve.o iplink_vrf.o iproute_lwtunnel.o ipmacsec.o ipila.o \
     ipvrf.o iplink_xstats.o ipseg6.o iplink_netdevsim.o iplink_rmnet.o \
-    ipnexthop.o ipmptcp.o iplink_bareudp.o
+    ipnexthop.o ipmptcp.o iplink_bareudp.o iplink_virtwifi.o
 
 RTMONOBJ=rtmon.o
 

--- a/ip/iplink_virtwifi.c
+++ b/ip/iplink_virtwifi.c
@@ -57,7 +57,7 @@ static int virt_wifi_parse_opt(struct link_util *lu, int argc, char **argv,
 		ifindex = ll_name_to_index(lower);
 		if (!ifindex)
 			return nodev(lower);
-		addattr32(n, 1024, IFLA_LINK, ifindex);
+		addattr32(n, 1024, IFLA_VIRTWIFI_LOWER, ifindex);
 	}
 
 	return 0;
@@ -68,8 +68,8 @@ static void virt_wifi_print_opt(struct link_util *lu, FILE *f, struct rtattr *tb
 	if (!tb)
 		return;
 
-	if (tb[IFLA_LINK]) {
-		int iflink = rta_getattr_u32(tb[IFLA_LINK]);
+	if (tb[IFLA_VIRTWIFI_LOWER]) {
+		int iflink = rta_getattr_u32(tb[IFLA_VIRTWIFI_LOWER]);
 		fprintf(f, "link %u: %s\n", iflink, ll_index_to_name(iflink));
 	}
 }
@@ -79,9 +79,6 @@ static void virt_wifi_print_help(struct link_util *lu, int argc, char **argv,
 {
 	print_explain(f);
 }
-
-// TODO: should be defined in kernel if_link.h
-#define IFLA_VIRTWIFI_MAX	1
 
 struct link_util virt_wifi_link_util = {
 	.id			= "virt_wifi",

--- a/ip/iplink_virtwifi.c
+++ b/ip/iplink_virtwifi.c
@@ -81,7 +81,7 @@ static void virt_wifi_print_help(struct link_util *lu, int argc, char **argv,
 }
 
 struct link_util virt_wifi_link_util = {
-	.id			= "virt_wifi",
+	.id		= "virt_wifi",
 	.maxattr	= IFLA_VIRTWIFI_MAX,
 	.parse_opt	= virt_wifi_parse_opt,
 	.print_opt	= virt_wifi_print_opt,

--- a/ip/iplink_virtwifi.c
+++ b/ip/iplink_virtwifi.c
@@ -58,7 +58,6 @@ static int virt_wifi_parse_opt(struct link_util *lu, int argc, char **argv,
 		if (!ifindex)
 			return nodev(lower);
 		addattr32(n, 1024, IFLA_LINK, ifindex);
-		// TODO: need to stuff something if IFLA_INFO_DATA to ensure .changelink gets called
 	}
 
 	return 0;
@@ -71,8 +70,7 @@ static void virt_wifi_print_opt(struct link_util *lu, FILE *f, struct rtattr *tb
 
 	if (tb[IFLA_LINK]) {
 		int iflink = rta_getattr_u32(tb[IFLA_LINK]);
-		(void)iflink;
-		// TODO: convert to name and print
+		fprintf(f, "link %u: %s\n", iflink, ll_index_to_name(iflink));
 	}
 }
 

--- a/ip/iplink_virtwifi.c
+++ b/ip/iplink_virtwifi.c
@@ -1,0 +1,94 @@
+/*
+ * iplink_virtwifi.c	virt_wifi device support
+ *
+ *              This program is free software; you can redistribute it and/or
+ *              modify it under the terms of the GNU General Public License
+ *              as published by the Free Software Foundation; either version
+ *              2 of the License, or (at your option) any later version.
+ *
+ * Authors:     Andrew Beltrano <anbeltra@microsoft.com>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "rt_names.h"
+#include "utils.h"
+#include "ip_common.h"
+
+static void print_explain(FILE *f)
+{
+	fprintf(f,
+		"Usage: ... virt_wifi\n"
+		"		[ lower { DEVICE } ]\n"
+		"\n"
+	);
+}
+
+static void explain(void)
+{
+	print_explain(stderr);
+}
+
+static int virt_wifi_parse_opt(struct link_util *lu, int argc, char **argv,
+			  struct nlmsghdr *n)
+{
+	char *lower = NULL;
+
+	while (argc > 0) {
+		if (matches(*argv, "lower") == 0) {
+			NEXT_ARG();
+			lower = *argv;
+		} else if (matches(*argv, "help") == 0) {
+			explain();
+			return -1;
+		} else {
+			fprintf(stderr, "virt_wifi: unknown command \"%s\"?\n", *argv);
+			explain();
+			return -1;
+		}
+		argc--, argv++;
+	}
+
+	if (lower) {
+		int ifindex;
+
+		ifindex = ll_name_to_index(lower);
+		if (!ifindex)
+			return nodev(lower);
+		addattr32(n, 1024, IFLA_LINK, ifindex);
+		// TODO: need to stuff something if IFLA_INFO_DATA to ensure .changelink gets called
+	}
+
+	return 0;
+}
+
+static void virt_wifi_print_opt(struct link_util *lu, FILE *f, struct rtattr *tb[])
+{
+	if (!tb)
+		return;
+
+	if (tb[IFLA_LINK]) {
+		int iflink = rta_getattr_u32(tb[IFLA_LINK]);
+		(void)iflink;
+		// TODO: convert to name and print
+	}
+}
+
+static void virt_wifi_print_help(struct link_util *lu, int argc, char **argv,
+			    FILE *f)
+{
+	print_explain(f);
+}
+
+// TODO: should be defined in kernel if_link.h
+#define IFLA_VIRTWIFI_MAX	1
+
+struct link_util virt_wifi_link_util = {
+	.id			= "virt_wifi",
+	.maxattr	= IFLA_VIRTWIFI_MAX,
+	.parse_opt	= virt_wifi_parse_opt,
+	.print_opt	= virt_wifi_print_opt,
+	.print_help	= virt_wifi_print_help,
+};


### PR DESCRIPTION
Enable changing the lower link of a virt_wifi device dynamically. Eg.

`ip link change link name wlan0 type virt_wifi lower eth1`

Corresponding changes to `include/uapi/linux/if_link.h` in the kernel tree are required.

## Notes
This PR is for illustrative purposes. I do not intend to send this to the original tree.